### PR TITLE
Support Perl 5.20.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 matrix:
   include:
     - language: perl
+      perl: "5.20"
+    - language: perl
       perl: "5.18"
     - language: perl
       perl: "5.16"


### PR DESCRIPTION
From Perl 5.20, some warnings are output.
https://movabletype.fogbugz.com/f/cases/112852/
https://movabletype.fogbugz.com/f/cases/113104/Output-a-warning-when-testing-t-09-image-orientation-t

This is a bug but this does not occur errors on Linux. I wont' fix this here.
