### PR TITLE
Perl 5.26 対応とテスト追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -124,4 +124,6 @@ script:
   - perl -v
   - php -v
   - PERL_HASH_SEED=0 perl -Ilocal/lib/perl5 local/bin/carton exec prove t plugins/*/t
+  - find . -name "*.cgi" | grep -v 'mt-config.cgi' | xargs -IFILENAME perl -c FILENAME > /dev/null
+  - find tools -type f | xargs -IFILENAME perl -It/lib -c FILENAME > /dev/null
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -124,6 +124,6 @@ script:
   - perl -v
   - php -v
   - PERL_HASH_SEED=0 perl -Ilocal/lib/perl5 local/bin/carton exec prove t plugins/*/t
-  - find . -name "*.cgi" | grep -v 'mt-config.cgi' | xargs -IFILENAME perl -c FILENAME > /dev/null
-  - find tools -type f | xargs -IFILENAME perl -It/lib -c FILENAME > /dev/null
+  - find . -name "*.cgi" | grep -v 'mt-config.cgi' | xargs -IFILENAME perl -Ilocal/lib/perl5 -c FILENAME > /dev/null
+  - find tools -type f | xargs -IFILENAME perl -It/lib -Ilocal/lib/perl5 -c FILENAME > /dev/null
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ matrix:
   include:
     # PHP 7.1
     - language: perl
+      perl: "5.26"
+    - language: perl
       perl: "5.24"
     - language: perl
       perl: "5.22"

--- a/cpanfile
+++ b/cpanfile
@@ -36,6 +36,7 @@ requires 'GD';
 requires 'Starlet';
 requires 'XML::LibXML';
 requires 'Server::Starter';
+requires 'Web::Scraper';
 
 on 'test' => sub {
     requires 'Clone';

--- a/mt-check.cgi
+++ b/mt-check.cgi
@@ -753,7 +753,8 @@ my $cwd = '';
     eval { $cwd = Cwd::getcwd() };
     if ( $bad || $@ ) {
         eval { $cwd = Cwd::cwd() };
-        if ( $@ && $@ !~ /Insecure \$ENV{PATH}/ ) {
+        my $insecure_error = "Insecure $ENV{PATH}";
+        if ( $@ && $@ !~ /$insecure_error/ ) {
             die $@;
         }
     }

--- a/t/04-config.t
+++ b/t/04-config.t
@@ -18,7 +18,7 @@ use MT;
 use MT::ConfigMgr;
 
 use vars qw( $BASE );
-require 't/test-common.pl';
+require './t/test-common.pl';
 
 my($cfg_file, $cfg, $mt);
 

--- a/t/64-objectmeta-memcached.t
+++ b/t/64-objectmeta-memcached.t
@@ -1,7 +1,7 @@
 #!/usr/bin/perl
 
 use strict;
-use lib qw( t/lib extlib lib ../lib ../extlib );
+use lib qw( t/lib extlib lib ../lib ../extlib . );
 
 BEGIN {
     $ENV{MT_CONFIG} = 'mysql-memcached-test.cfg';

--- a/wercker.yml
+++ b/wercker.yml
@@ -63,4 +63,6 @@ build:
         name: Run test
         code: |
           prove -w t plugins/*t/
+          find . -name "*.cgi" | grep -v 'mt-config.cgi' | xargs -IFILENAME perl -c FILENAME > /dev/null
+          find tools -type f | xargs -IFILENAME perl -It/lib -c FILENAME > /dev/null
 


### PR DESCRIPTION
* Perl 5.26 でテストする
* *.cgi, tools のファイルのテスト
* mt-check.cgi の Perl 5.26 での不具合修正
